### PR TITLE
Fix a byte offset bug in `Time.Formatter`.

### DIFF
--- a/spec/Time.Formatter.Spec.savi
+++ b/spec/Time.Formatter.Spec.savi
@@ -59,6 +59,7 @@
     assert: t.format("%3N") == "006"
     assert: t.format("%6N") == "006000"
     assert: t.format("%9N") == "006000000"
+    assert: t.format("%3Nabc") == "006abc"
 
     // assert: t.format("%z") == "+0000"
     // assert: t.format("%:z") == "+00:00"

--- a/src/Time.Formatter.savi
+++ b/src/Time.Formatter.savi
@@ -139,7 +139,6 @@
               | digit_char == '6' | out << @microseconds(time)
               | digit_char == '9' | out << @nanoseconds(time)
               )
-              i += 1
             |
               ok = False
               out.push_byte('%')


### PR DESCRIPTION
This was previously causing formatted strings to skip a byte
after formatting a `%3N`, `%6N`, or `%9N` code.