### PR TITLE
Update away from deprecated names in latest Savi version.

### DIFF
--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -1,4 +1,4 @@
-:ffi _FFI
+:ffimodule _FFI
   :: C function used to get the current time on MacOS.
   :fun gettimeofday(
     time_pair_out CPointer(Pair(U64, U64))


### PR DESCRIPTION
- Prefer `:ffimodule` over `:ffi`.