### PR TITLE
Add `Time.Duration` data type.

### DIFF
--- a/spec/Main.savi
+++ b/spec/Main.savi
@@ -2,6 +2,7 @@
   :new (env)
     Spec.Process.run(env, [
       Spec.Run(Time.Spec).new(env)
+      Spec.Run(Time.Duration.Spec).new(env)
       Spec.Run(Time.Formatter.Spec).new(env)
       Spec.Run(Time.Measure.Spec).new(env)
     ])

--- a/spec/Time.Duration.Spec.savi
+++ b/spec/Time.Duration.Spec.savi
@@ -1,0 +1,206 @@
+:class Time.Duration.Spec
+  :is Spec
+  :const describes: "Time.Duration"
+
+  :it "can construct a duration in various units"
+    assert: Time.Duration.weeks(3) == Time.Duration.days(21)
+    assert: Time.Duration.days(3) == Time.Duration.hours(72)
+    assert: Time.Duration.hours(3) == Time.Duration.minutes(180)
+    assert: Time.Duration.minutes(3) == Time.Duration.seconds(180)
+    assert: Time.Duration.seconds(3) == Time.Duration.milliseconds(3000)
+    assert: Time.Duration.milliseconds(3) == Time.Duration.microseconds(3000)
+    assert: Time.Duration.microseconds(3) == Time.Duration.nanoseconds(3000)
+
+  :it "can export to a smaller unit without loss of precision"
+    assert: Time.Duration.weeks(3).total_weeks == 3
+    assert: Time.Duration.weeks(3).total_days == 21
+    assert: Time.Duration.days(3).total_hours == 72
+    assert: Time.Duration.hours(3).total_minutes == 180
+    assert: Time.Duration.minutes(3).total_seconds == 180
+    // Everything smaller than `total_seconds` may raise an error
+    // because it may overflow the bounds of the `U64` result.
+    assert: Time.Duration.seconds(3).total_milliseconds! == 3000
+    assert: Time.Duration.milliseconds(3).total_microseconds! == 3000
+    assert: Time.Duration.microseconds(3).total_nanoseconds! == 3000
+
+  :it "overflows the bounds of the U64 export when the duration is too long"
+    assert:       U64.max_value ==      18446744073709551615
+    assert:       Time.Duration.seconds(18446744073709551).total_milliseconds! == 18446744073709551000
+    assert error: Time.Duration.seconds(18446744073709552).total_milliseconds!
+    assert:       Time.Duration.seconds(18446744073709).total_microseconds! == 18446744073709000000
+    assert error: Time.Duration.seconds(18446744073710).total_microseconds!
+    assert:       Time.Duration.seconds(18446744073).total_nanoseconds! == 18446744073000000000
+    assert error: Time.Duration.seconds(18446744074).total_nanoseconds!
+
+  :it "can export to a larger unit losing precision (rounding down)"
+    assert: Time.Duration.days(21).total_weeks == 3
+    assert: Time.Duration.days(27).total_weeks == 3
+    assert: Time.Duration.days(28).total_weeks == 4
+    assert: Time.Duration.hours(72).total_days == 3
+    assert: Time.Duration.hours(95).total_days == 3
+    assert: Time.Duration.hours(96).total_days == 4
+    assert: Time.Duration.minutes(180).total_hours == 3
+    assert: Time.Duration.minutes(239).total_hours == 3
+    assert: Time.Duration.minutes(240).total_hours == 4
+    assert: Time.Duration.seconds(180).total_minutes == 3
+    assert: Time.Duration.seconds(239).total_minutes == 3
+    assert: Time.Duration.seconds(240).total_minutes == 4
+    assert: Time.Duration.milliseconds(3000).total_seconds == 3
+    assert: Time.Duration.milliseconds(3999).total_seconds == 3
+    assert: Time.Duration.milliseconds(4000).total_seconds == 4
+    assert: Time.Duration.microseconds(3000).total_milliseconds! == 3
+    assert: Time.Duration.microseconds(3999).total_milliseconds! == 3
+    assert: Time.Duration.microseconds(4000).total_milliseconds! == 4
+    assert: Time.Duration.nanoseconds(3000).total_microseconds! == 3
+    assert: Time.Duration.nanoseconds(3999).total_microseconds! == 3
+    assert: Time.Duration.nanoseconds(4000).total_microseconds! == 4
+
+  :it "can chain additive amounts onto an original duration"
+    t = Time.Duration
+    assert: t.weeks(3) + t.weeks(6) == t.weeks(9)
+    assert: t.weeks(3).plus_weeks(6) == t.weeks(9)
+    assert: t.weeks(3) + t.days(6) == t.days(27)
+    assert: t.weeks(3).plus_days(6) == t.days(27)
+    assert: t.days(3) + t.hours(6) == t.hours(78)
+    assert: t.days(3).plus_hours(6) == t.hours(78)
+    assert: t.hours(3) + t.minutes(6) == t.minutes(186)
+    assert: t.hours(3).plus_minutes(6) == t.minutes(186)
+    assert: t.minutes(3) + t.seconds(6) == t.seconds(186)
+    assert: t.minutes(3).plus_seconds(6) == t.seconds(186)
+    assert: t.seconds(3) + t.milliseconds(6) == t.milliseconds(3006)
+    assert: t.seconds(3).plus_milliseconds(6) == t.milliseconds(3006)
+    assert: t.milliseconds(3) + t.microseconds(6) == t.microseconds(3006)
+    assert: t.milliseconds(3).plus_microseconds(6) == t.microseconds(3006)
+    assert: t.microseconds(3) + t.nanoseconds(6) == t.nanoseconds(3006)
+    assert: t.microseconds(3).plus_nanoseconds(6) == t.nanoseconds(3006)
+
+  :it "can chain subtractive amounts onto an original duration"
+    t = Time.Duration
+    assert: t.weeks(9) - t.weeks(6) == t.weeks(3)
+    assert: t.weeks(9).minus_weeks(6) == t.weeks(3)
+    assert: t.weeks(3) - t.days(6) == t.days(15)
+    assert: t.weeks(3).minus_days(6) == t.days(15)
+    assert: t.days(3) - t.hours(6) == t.hours(66)
+    assert: t.days(3).minus_hours(6) == t.hours(66)
+    assert: t.hours(3) - t.minutes(6) == t.minutes(174)
+    assert: t.hours(3).minus_minutes(6) == t.minutes(174)
+    assert: t.minutes(3) - t.seconds(6) == t.seconds(174)
+    assert: t.minutes(3).minus_seconds(6) == t.seconds(174)
+    assert: t.seconds(3) - t.milliseconds(6) == t.milliseconds(2994)
+    assert: t.seconds(3).minus_milliseconds(6) == t.milliseconds(2994)
+    assert: t.milliseconds(3) - t.microseconds(6) == t.microseconds(2994)
+    assert: t.milliseconds(3).minus_microseconds(6) == t.microseconds(2994)
+    assert: t.microseconds(3) - t.nanoseconds(6) == t.nanoseconds(2994)
+    assert: t.microseconds(3).minus_nanoseconds(6) == t.nanoseconds(2994)
+
+  :it "has wrap-around overflow semantics by default when adding"
+    t = Time.Duration
+    max = t.max_value
+    assert: max + t.nanoseconds(3) == t.nanoseconds(2)
+    assert: max.plus_nanoseconds(3) == t.nanoseconds(2)
+    assert: max + t.microseconds(3) == t.nanoseconds(2999)
+    assert: max.plus_microseconds(3) == t.nanoseconds(2999)
+    assert: max + t.milliseconds(3) == t.nanoseconds(2999999)
+    assert: max.plus_milliseconds(3) == t.nanoseconds(2999999)
+    assert: max + t.seconds(3) == t.seconds(3) - t.nanoseconds(1)
+    assert: max.plus_seconds(3) == t.seconds(3) - t.nanoseconds(1)
+    assert: max + t.minutes(3) == t.minutes(3) - t.nanoseconds(1)
+    assert: max.plus_minutes(3) == t.minutes(3) - t.nanoseconds(1)
+    assert: max + t.hours(3) == t.hours(3) - t.nanoseconds(1)
+    assert: max.plus_hours(3) == t.hours(3) - t.nanoseconds(1)
+    assert: max + t.days(3) == t.days(3) - t.nanoseconds(1)
+    assert: max.plus_days(3) == t.days(3) - t.nanoseconds(1)
+    assert: max + t.weeks(3) == t.weeks(3) - t.nanoseconds(1)
+    assert: max.plus_weeks(3) == t.weeks(3) - t.nanoseconds(1)
+
+  :it "can raise an error on overflow when adding with exclamation point"
+    t = Time.Duration
+    max = t.max_value
+    assert: max == (max - t.nanoseconds(2)) +! t.nanoseconds(2)
+    assert: max == (max - t.nanoseconds(2)).plus_nanoseconds!(2)
+    assert error:  (max - t.nanoseconds(2)) +! t.nanoseconds(3)
+    assert error:  (max - t.nanoseconds(2)).plus_nanoseconds!(3)
+    assert: max == (max - t.microseconds(2)) +! t.microseconds(2)
+    assert: max == (max - t.microseconds(2)).plus_microseconds!(2)
+    assert error:  (max - t.microseconds(2)) +! t.microseconds(3)
+    assert error:  (max - t.microseconds(2)).plus_microseconds!(3)
+    assert: max == (max - t.milliseconds(2)) +! t.milliseconds(2)
+    assert: max == (max - t.milliseconds(2)).plus_milliseconds!(2)
+    assert error:  (max - t.milliseconds(2)) +! t.milliseconds(3)
+    assert error:  (max - t.milliseconds(2)).plus_milliseconds!(3)
+    assert: max == (max - t.seconds(2)) +! t.seconds(2)
+    assert: max == (max - t.seconds(2)).plus_seconds!(2)
+    assert error:  (max - t.seconds(2)) +! t.seconds(3)
+    assert error:  (max - t.seconds(2)).plus_seconds!(3)
+    assert: max == (max - t.minutes(2)) +! t.minutes(2)
+    assert: max == (max - t.minutes(2)).plus_minutes!(2)
+    assert error:  (max - t.minutes(2)) +! t.minutes(3)
+    assert error:  (max - t.minutes(2)).plus_minutes!(3)
+    assert: max == (max - t.hours(2)) +! t.hours(2)
+    assert: max == (max - t.hours(2)).plus_hours!(2)
+    assert error:  (max - t.hours(2)) +! t.hours(3)
+    assert error:  (max - t.hours(2)).plus_hours!(3)
+    assert: max == (max - t.days(2)) +! t.days(2)
+    assert: max == (max - t.days(2)).plus_days!(2)
+    assert error:  (max - t.days(2)) +! t.days(3)
+    assert error:  (max - t.days(2)).plus_days!(3)
+    assert: max == (max - t.weeks(2)) +! t.weeks(2)
+    assert: max == (max - t.weeks(2)).plus_weeks!(2)
+    assert error:  (max - t.weeks(2)) +! t.weeks(3)
+    assert error:  (max - t.weeks(2)).plus_weeks!(3)
+
+  :it "has wrap-around underflow semantics by default when subtracting"
+    t = Time.Duration
+    max = t.max_value
+    assert: t.nanoseconds(2) - t.nanoseconds(5) == max - t.nanoseconds(2)
+    assert: t.nanoseconds(2) - t.nanoseconds(5) == max - t.nanoseconds(2)
+    assert: t.microseconds(2) - t.microseconds(5) == max - t.nanoseconds(2999)
+    assert: t.microseconds(2) - t.microseconds(5) == max - t.nanoseconds(2999)
+    assert: t.milliseconds(2) - t.milliseconds(5) == max - t.nanoseconds(2999999)
+    assert: t.milliseconds(2) - t.milliseconds(5) == max - t.nanoseconds(2999999)
+    assert: t.seconds(2) -   t.seconds(5) == max - t.seconds(3) + t.nanoseconds(1)
+    assert: t.seconds(2).minus_seconds(5) == max - t.seconds(3) + t.nanoseconds(1)
+    assert: t.minutes(2) -   t.minutes(5) == max - t.minutes(3) + t.nanoseconds(1)
+    assert: t.minutes(2).minus_minutes(5) == max - t.minutes(3) + t.nanoseconds(1)
+    assert: t.hours(2) -   t.hours(5) == max - t.hours(3) + t.nanoseconds(1)
+    assert: t.hours(2).minus_hours(5) == max - t.hours(3) + t.nanoseconds(1)
+    assert: t.days(2) -   t.days(5) == max - t.days(3) + t.nanoseconds(1)
+    assert: t.days(2).minus_days(5) == max - t.days(3) + t.nanoseconds(1)
+    assert: t.weeks(2) -   t.weeks(5) == max - t.weeks(3) + t.nanoseconds(1)
+    assert: t.weeks(2).minus_weeks(5) == max - t.weeks(3) + t.nanoseconds(1)
+
+  :it "can raise an error on underflow when subtracting with exclamation point"
+    t = Time.Duration
+    zero = t.zero
+    assert: zero == t.nanoseconds(5) -! t.nanoseconds(5)
+    assert: zero == t.nanoseconds(5).minus_nanoseconds!(5)
+    assert error:   t.nanoseconds(5) -! t.nanoseconds(6)
+    assert error:   t.nanoseconds(5).minus_nanoseconds!(6)
+    assert: zero == t.microseconds(5) -! t.microseconds(5)
+    assert: zero == t.microseconds(5).minus_microseconds!(5)
+    assert error:   t.microseconds(5) -! t.microseconds(6)
+    assert error:   t.microseconds(5).minus_microseconds!(6)
+    assert: zero == t.milliseconds(5) -! t.milliseconds(5)
+    assert: zero == t.milliseconds(5).minus_milliseconds!(5)
+    assert error:   t.milliseconds(5) -! t.milliseconds(6)
+    assert error:   t.milliseconds(5).minus_milliseconds!(6)
+    assert: zero == t.seconds(5) -! t.seconds(5)
+    assert: zero == t.seconds(5).minus_seconds!(5)
+    assert error:   t.seconds(5) -! t.seconds(6)
+    assert error:   t.seconds(5).minus_seconds!(6)
+    assert: zero == t.minutes(5) -! t.minutes(5)
+    assert: zero == t.minutes(5).minus_minutes!(5)
+    assert error:   t.minutes(5) -! t.minutes(6)
+    assert error:   t.minutes(5).minus_minutes!(6)
+    assert: zero == t.hours(5) -! t.hours(5)
+    assert: zero == t.hours(5).minus_hours!(5)
+    assert error:   t.hours(5) -! t.hours(6)
+    assert error:   t.hours(5).minus_hours!(6)
+    assert: zero == t.days(5) -! t.days(5)
+    assert: zero == t.days(5).minus_days!(5)
+    assert error:   t.days(5) -! t.days(6)
+    assert error:   t.days(5).minus_days!(6)
+    assert: zero == t.weeks(5) -! t.weeks(5)
+    assert: zero == t.weeks(5).minus_weeks!(5)
+    assert error:   t.weeks(5) -! t.weeks(6)
+    assert error:   t.weeks(5).minus_weeks!(6)

--- a/spec/Time.Spec.savi
+++ b/spec/Time.Spec.savi
@@ -26,18 +26,18 @@
     assert: time.month == 11
     assert: time.day   == 1
 
-  :it "can add or subtract other time durations"
+  :it "can add or subtract time durations"
     assert:
-      (Time.utc(2036, 10, 7, 20, 36, 10, 777) - Time.days(3))
+      (Time.utc(2036, 10, 7, 20, 36, 10, 777) - Time.Duration.days(3))
       == Time.utc(2036, 10, 4, 20, 36, 10, 777)
     assert:
-      (Time.utc(2036, 10, 7, 20, 36, 10, 777) + Time.hours(7))
+      (Time.utc(2036, 10, 7, 20, 36, 10, 777) + Time.Duration.hours(7))
       == Time.utc(2036, 10, 8, 3, 36, 10, 777)
 
   :it "can be compared to other times"
     now = Time.utc(2036, 10, 7, 20, 36, 10, 777)
-    soon = now + Time.nanoseconds(13)
-    later = now + Time.hours(12)
+    soon = now + Time.Duration.nanoseconds(13)
+    later = now + Time.Duration.hours(12)
     assert: now < later
     assert: now <= later
     assert: (now == later).is_false

--- a/src/Time.Duration.savi
+++ b/src/Time.Duration.savi
@@ -1,0 +1,520 @@
+:struct val Time.Duration
+  :is Comparable(Time.Duration)
+
+  :: The total number of seconds in the duration.
+  :let total_seconds U64
+  :: The number of nanoseconds past the second.
+  :let nanosecond U32
+
+  :: An internal-only direct constructor.
+  :new val _new(@total_seconds, @nanosecond)
+
+  :: The maximum duration representable by this data type.
+  :fun non max_value: @_new(U64.max_value, Time._nanoseconds_per_second - 1)
+
+  :: The minimum duration representable by this data type (a.k.a `zero`).
+  :fun non min_value: @_new(0, 0)
+
+  :: A duration of zero length.
+  :fun non zero: @_new(0, 0)
+
+  :: Represent a duration of the given number of nanoseconds.
+  :new nanoseconds(n U64):
+    if (n < 1000000000) (
+      @total_seconds = 0
+      @nanosecond = n.u32
+    |
+      @total_seconds = n / 1000000000
+      @nanosecond = (n % 1000000000).u32
+    )
+
+  :: Represent a duration of the given number of microseconds.
+  :new microseconds(n U64)
+    if (n < 1000000) (
+      @total_seconds = 0
+      @nanosecond = n.u32 * 1000
+    |
+      @total_seconds = n / 1000000
+      @nanosecond = (n % 1000000).u32 * 1000
+    )
+
+  :: Represent a duration of the given number of milliseconds.
+  :new milliseconds(n U64)
+    if (n < 1000) (
+      @total_seconds = 0
+      @nanosecond = n.u32 * 1000000
+    |
+      @total_seconds = n / 1000
+      @nanosecond = (n % 1000).u32 * 1000000
+    )
+
+  :: Represent a duration of the given number of seconds.
+  :new seconds(n)
+    @total_seconds = n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of minutes.
+  :new minutes(n)
+    @total_seconds = Time._seconds_per_minute * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of hours.
+  :new hours(n)
+    @total_seconds = Time._seconds_per_hour * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of days.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :new days(n)
+    @total_seconds = Time._seconds_per_day * n
+    @nanosecond = 0
+
+  :: Represent a duration of the given number of 7-day weeks.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :new weeks(n)
+    @total_seconds = Time._seconds_per_day * 7 * n
+    @nanosecond = 0
+
+  :: Return the total number of complete weeks in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_weeks: @total_seconds / (Time._seconds_per_day * 7)
+
+  :: Return the total number of complete days in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_days: @total_seconds / Time._seconds_per_day
+
+  :: Return the total number of complete hours in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  :fun total_hours: @total_seconds / Time._seconds_per_hour
+
+  :: Return the total number of complete minutes in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  :fun total_minutes: @total_seconds / Time._seconds_per_minute
+
+  :: Return the total number of complete milliseconds in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_milliseconds!
+    (@total_seconds *! 1000) +! (@nanosecond / 1000000).u64
+
+  :: Return the total number of complete microseconds in the duration.
+  :: That is, if precision is lost, the result is rounded down.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_microseconds!
+    (@total_seconds *! 1000000) +! (@nanosecond / 1000).u64
+
+  :: Return the total number of nanoseconds in the duration.
+  ::
+  :: Raises an error if the result would be higher than `U64.max_value`.
+  :fun total_nanoseconds!
+    (@total_seconds *! 1000000000) +! @nanosecond.u64
+
+  :: Return the total number of complete weeks in the duration.
+  :: The remainder of the duration (beyond those weeks) is also returned.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_weeks_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / (Time._seconds_per_day * 7)
+      @_new(
+        @total_seconds % (Time._seconds_per_day * 7)
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete days in the duration.
+  :: The remainder of the duration (beyond those days) is also returned.
+  ::
+  :: Assumes ideal days (24 hours, 60 minutes per hour, 60 seconds per minute).
+  :fun total_days_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_day
+      @_new(
+        @total_seconds % Time._seconds_per_day
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete hours in the duration.
+  :: The remainder of the duration (beyond those hours) is also returned.
+  :fun total_hours_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_hour
+      @_new(
+        @total_seconds % Time._seconds_per_hour
+        @nanosecond
+      )
+    )
+
+  :: Return the total number of complete minutes in the duration.
+  :: The remainder of the duration (beyond those minutes) is also returned.
+  :fun total_minutes_with_remainder
+    Pair(U64, Time.Duration).new(
+      @total_seconds / Time._seconds_per_minute
+      @_new(
+        @total_seconds % Time._seconds_per_minute
+        @nanosecond
+      )
+    )
+
+  :: Print the duration for human inspection (the format is subject to change).
+  :fun inspect_into(output String'iso)
+    weeks_result = @total_weeks_with_remainder
+    days_result = weeks_result.tail.total_days_with_remainder
+    hours_result = days_result.tail.total_hours_with_remainder
+    minutes_result = hours_result.tail.total_minutes_with_remainder
+
+    weeks = weeks_result.head
+    days = days_result.head
+    hours = hours_result.head
+    minutes = minutes_result.head
+    seconds = minutes_result.tail.total_seconds
+    nanoseconds = minutes_result.tail.nanosecond
+
+    printed_anything = False
+    output << "Time.Duration("
+
+    if (weeks > 0) (
+      output = Inspect.into(--output, weeks), output << " weeks"
+      printed_anything = True
+    )
+
+    if (days > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, days), output << " days"
+      printed_anything = True
+    )
+
+    if (hours > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, hours), output << " hours"
+      printed_anything = True
+    )
+
+    if (minutes > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, minutes), output << " minutes"
+      printed_anything = True
+    )
+
+    if (seconds > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, seconds), output << " seconds"
+      printed_anything = True
+    )
+
+    if (nanoseconds > 0) (
+      if printed_anything (output << ", ")
+      output = Inspect.into(--output, nanoseconds), output << " nanoseconds"
+      printed_anything = True
+    )
+
+    output << ")"
+    --output
+
+  :: Return True if the given duration is exactly equivalent to this one.
+  :fun "=="(other Time.Duration'box)
+    @total_seconds == other.total_seconds
+    && @nanosecond == other.nanosecond
+
+  :: Return True if the given duration is less than (earlier than) this one.
+  :fun "<"(other Time.Duration'box)
+    @total_seconds < other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond < other.nanosecond)
+
+  :: Return True if the given duration is greater than (later than) this one.
+  :fun ">"(other Time.Duration'box)
+    @total_seconds > other.total_seconds
+    || (@total_seconds == other.total_seconds && @nanosecond > other.nanosecond)
+
+  :: Add the given duration to this one and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use the `+!` method instead.
+  :fun "+"(other Time.Duration'box)
+    total = @total_seconds + other.total_seconds
+    nanos = @nanosecond + other.nanosecond
+    while (nanos >= Time._nanoseconds_per_second) (
+      nanos -= Time._nanoseconds_per_second
+      total += 1
+    )
+    @_new(total, nanos)
+
+  :: Add the given duration to this one and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow semantics are desired, use the `+` method instead.
+  :fun "+!"(other Time.Duration'box)
+    total = @total_seconds +! other.total_seconds
+    nanos = @nanosecond + other.nanosecond
+    while (nanos >= Time._nanoseconds_per_second) (
+      nanos -= Time._nanoseconds_per_second
+      total = total +! 1
+    )
+    @_new(total, nanos)
+
+  :: Subtract the given duration from this one and return the result.
+  ::
+  :: Uses wrap-around underflow semantics if the result is less than `zero`.
+  :: If an error on underflow is desired, use the `-!` method instead.
+  :fun "-"(other Time.Duration'box)
+    total = @total_seconds, other_total = other.total_seconds
+    nanos = @nanosecond,    other_nanos = other.nanosecond
+    while (nanos < other_nanos) (
+      nanos += Time._nanoseconds_per_second
+      total -= 1
+    )
+    @_new(total - other_total, nanos - other_nanos)
+
+  :: Subtract the given duration from this one and return the result.
+  ::
+  :: Raises an error if the result would be less than `zero`.
+  :: If wrap-around underflow semantics is desired, use the `-` method instead.
+  :fun "-!"(other Time.Duration'box)
+    total = @total_seconds, other_total = other.total_seconds
+    nanos = @nanosecond,    other_nanos = other.nanosecond
+    while (nanos < other_nanos) (
+      nanos += Time._nanoseconds_per_second
+      total = total -! 1
+    )
+    @_new(total -! other_total, nanos - other_nanos)
+
+  :: Add the given number of weeks to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_weeks!` instead.
+  :fun plus_weeks(n)
+    @_new(
+      @total_seconds + Time._seconds_per_day * 7 * n
+      @nanosecond
+    )
+
+  :: Add the given number of weeks to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_weeks` instead.
+  :fun plus_weeks!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_day * 7 *! n
+      @nanosecond
+    )
+
+  :: Add the given number of days to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_days!` instead.
+  :fun plus_days(n)
+    @_new(
+      @total_seconds + Time._seconds_per_day * n
+      @nanosecond
+    )
+
+  :: Add the given number of days to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_days` instead.
+  :fun plus_days!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_day *! n
+      @nanosecond
+    )
+
+  :: Add the given number of hours to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_hours!` instead.
+  :fun plus_hours(n)
+    @_new(
+      @total_seconds + Time._seconds_per_hour * n
+      @nanosecond
+    )
+
+  :: Add the given number of hours to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_hours` instead.
+  :fun plus_hours!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_hour *! n
+      @nanosecond
+    )
+
+  :: Add the given number of minutes to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_minutes!` instead.
+  :fun plus_minutes(n)
+    @_new(
+      @total_seconds + Time._seconds_per_minute * n
+      @nanosecond
+    )
+
+  :: Add the given number of minutes to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_minutes` instead.
+  :fun plus_minutes!(n)
+    @_new(
+      @total_seconds +! Time._seconds_per_minute *! n
+      @nanosecond
+    )
+
+  :: Add the given number of seconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_seconds!` instead.
+  :fun plus_seconds(n)
+    @_new(
+      @total_seconds + n
+      @nanosecond
+    )
+
+  :: Add the given number of seconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_seconds` instead.
+  :fun plus_seconds!(n)
+    @_new(
+      @total_seconds +! n
+      @nanosecond
+    )
+
+  :: Add the given milliseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_milliseconds!` instead.
+  :fun plus_milliseconds(n): @ + @milliseconds(n)
+
+  :: Add the given milliseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_milliseconds` instead.
+  :fun plus_milliseconds!(n): @ +! @milliseconds(n)
+
+  :: Add the given microseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_microseconds!` instead.
+  :fun plus_microseconds(n): @ + @microseconds(n)
+
+  :: Add the given microseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_microseconds` instead.
+  :fun plus_microseconds!(n): @ +! @microseconds(n)
+
+  :: Add the given nanoseconds to this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `plus_nanoseconds!` instead.
+  :fun plus_nanoseconds(n): @ + @nanoseconds(n)
+
+  :: Add the given nanoseconds to this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `plus_nanoseconds` instead.
+  :fun plus_nanoseconds!(n): @ +! @nanoseconds(n)
+
+  :: Subtract the given weeks from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_weeks!` instead.
+  :fun minus_weeks(n): @ - @weeks(n)
+
+  :: Subtract the given weeks from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_weeks` instead.
+  :fun minus_weeks!(n): @ -! @weeks(n)
+
+  :: Subtract the given days from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_days!` instead.
+  :fun minus_days(n): @ - @days(n)
+
+  :: Subtract the given days from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_days` instead.
+  :fun minus_days!(n): @ -! @days(n)
+
+  :: Subtract the given hours from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_hours!` instead.
+  :fun minus_hours(n): @ - @hours(n)
+
+  :: Subtract the given hours from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_hours` instead.
+  :fun minus_hours!(n): @ -! @hours(n)
+
+  :: Subtract the given minutes from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_minutes!` instead.
+  :fun minus_minutes(n): @ - @minutes(n)
+
+  :: Subtract the given minutes from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_minutes` instead.
+  :fun minus_minutes!(n): @ -! @minutes(n)
+
+  :: Subtract the given seconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_seconds!` instead.
+  :fun minus_seconds(n): @ - @seconds(n)
+
+  :: Subtract the given seconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_seconds` instead.
+  :fun minus_seconds!(n): @ -! @seconds(n)
+
+  :: Subtract the given milliseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_milliseconds!` instead.
+  :fun minus_milliseconds(n): @ - @milliseconds(n)
+
+  :: Subtract the given milliseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_milliseconds` instead.
+  :fun minus_milliseconds!(n): @ -! @milliseconds(n)
+
+  :: Subtract the given microseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_microseconds!` instead.
+  :fun minus_microseconds(n): @ - @microseconds(n)
+
+  :: Subtract the given microseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_microseconds` instead.
+  :fun minus_microseconds!(n): @ -! @microseconds(n)
+
+  :: Subtract the given nanoseconds from this duration and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use `minus_nanoseconds!` instead.
+  :fun minus_nanoseconds(n): @ - @nanoseconds(n)
+
+  :: Subtract the given nanoseconds from this duration and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow is desired, use `minus_nanoseconds` instead.
+  :fun minus_nanoseconds!(n): @ -! @nanoseconds(n)

--- a/src/Time.savi
+++ b/src/Time.savi
@@ -5,7 +5,6 @@
 :: The number of seconds is represented with 64-bit integer precision,
 :: with an additional 32-bit integer to specify nanoseconds within the second.
 
-
 :enum Time.DayOfWeek
   :member NoDay: 0
   :member Monday: 1
@@ -51,6 +50,15 @@
   :: An internal-only direct constructor.
   :new val _new(@total_seconds, @nanosecond)
 
+  :: The maximum duration representable by this data type.
+  :fun non max_value: @_new(U64.max_value, Time._nanoseconds_per_second - 1)
+
+  :: The minimum duration representable by this data type (a.k.a `zero`).
+  :fun non min_value: @_new(0, 0)
+
+  :: A duration of zero length.
+  :fun non zero: @_new(0, 0)
+
   :: Represent the moment in time indicated by the given year, month, day,
   :: and optional hour, minute, second, and nanosecond (in the UTC time zone).
   :new val utc(
@@ -69,6 +77,7 @@
       + second.u64
 
   :: Represent a duration of the given number of nanoseconds.
+  :: DEPRECATED: Use `Time.Duration.nanoseconds` instead.
   :new nanoseconds(n U32):
     @total_seconds = 0
     while (@_nanoseconds_per_second < n) (
@@ -78,15 +87,19 @@
     @nanosecond = n
 
   :: Represent a duration of the given number of seconds.
+  :: DEPRECATED: Use `Time.Duration.seconds` instead.
   :new seconds(n): @nanosecond = 0, @total_seconds = n
 
   :: Represent a duration of the given number of minutes.
+  :: DEPRECATED: Use `Time.Duration.minutes` instead.
   :new minutes(n): @nanosecond = 0, @total_seconds = @_seconds_per_minute * n
 
   :: Represent a duration of the given number of hours.
+  :: DEPRECATED: Use `Time.Duration.hours` instead.
   :new hours(n): @nanosecond = 0, @total_seconds = @_seconds_per_hour * n
 
   :: Represent a duration of the given number of days.
+  :: DEPRECATED: Use `Time.Duration.days` instead.
   :new days(n): @nanosecond = 0, @total_seconds = @_seconds_per_day * n
 
   :: Return True if the given time is exactly equivalent to this one.
@@ -104,31 +117,37 @@
     @total_seconds > other.total_seconds
     || (@total_seconds == other.total_seconds && @nanosecond > other.nanosecond)
 
-  :: Subtract the given time (elapsed since `0001-01-01 00:00:00.0` UTC)
-  :: from this time and return the result.
-  :fun "-"(other Time'box)
-    total = @total_seconds, other_total = other.total_seconds
-    nano  = @nanosecond,    other_nano  = other.nanosecond
+  :: Add the given duration to this time and return the result.
+  ::
+  :: Uses wrap-around overflow semantics if the result is more than `max_value`.
+  :: If an error on overflow is desired, use the `+!` method instead.
+  :fun "+"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) + other
+    @_new(result.total_seconds, result.nanosecond)
 
-    while (nano < other_nano) (
-      nano += @_nanoseconds_per_second
-      other_total += 1
-    )
+  :: Add the given duration to this time and return the result.
+  ::
+  :: Raises an error if the result would be more than `max_value`.
+  :: If wrap-around overflow semantics are desired, use the `+` method instead.
+  :fun "+!"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) +! other
+    @_new(result.total_seconds, result.nanosecond)
 
-    Time._new(total - other_total, nano - other_nano)
+  :: Subtract the given duration from this time and return the result.
+  ::
+  :: Uses wrap-around underflow semantics if the result is less than `zero`.
+  :: If an error on underflow is desired, use the `-!` method instead.
+  :fun "-"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) - other
+    @_new(result.total_seconds, result.nanosecond)
 
-  :: Add the given time (elapsed since `0001-01-01 00:00:00.0` UTC)
-  :: to this time and return the result.
-  :fun "+"(other Time'box)
-    total = @total_seconds + other.total_seconds
-    nano  = @nanosecond    + other.nanosecond
-
-    while (nano > @_nanoseconds_per_second) (
-      nano -= @_nanoseconds_per_second
-      total += 1
-    )
-
-    Time._new(total, nano)
+  :: Subtract the given duration from this time and return the result.
+  ::
+  :: Raises an error if the result would be less than `zero`.
+  :: If wrap-around underflow semantics is desired, use the `-` method instead.
+  :fun "-!"(other Time.Duration'box)
+    result = Time.Duration._new(@total_seconds, @nanosecond) -! other
+    @_new(result.total_seconds, result.nanosecond)
 
   :: Returns the year (a number greater than or equal to 1).
   :fun year U32


### PR DESCRIPTION
It uses the same internal numbers as the `Time` struct, but it has
the semantics of being a duration of time rather than an absolute
point in time relative to the start of the Common Era
in the proleptic Gregorian calendar (as `Time` does).

`Time.+` and `Time.-` have been changed to accept a `Time.Duration`
instead of an absolute `Time` (and they still return an absolute `Time`).