### PR TITLE
Add Windows support.

### DIFF
--- a/.github/workflows/library-check.yaml
+++ b/.github/workflows/library-check.yaml
@@ -24,13 +24,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{matrix.os}}
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: windows-latest, shell: 'wsl-bash {0}' }
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     steps:
       - uses: actions/checkout@v2
-      - uses: savi-lang/action-install@v1.0.0
+      - uses: savi-lang/action-install@v1.1.0
       - run: savi deps update --for spec
-      - run: savi run spec
+      - run: savi run spec ${{ runner.os == 'Windows' && '--cross-compile=x86_64-unknown-windows-msvc' || '' }}
 
   # Check formatting of all files in the repository.
   format:

--- a/spec/Time.Measure.Spec.savi
+++ b/spec/Time.Measure.Spec.savi
@@ -50,4 +50,15 @@
 // it's reasonable because it helps us test a specific non-zero amount of
 // time passing inside the block we are measuring.
 :module _FFI.TestHacks
-  :ffi sleep(seconds I32) I32
+  :fun sleep(seconds U32)
+    if Platform.is_posix (
+      @_posix_sleep_seconds(seconds.i32)
+    |
+      @_windows_sleep_milliseconds(seconds * 1000)
+    )
+
+  :ffi _posix_sleep_seconds(seconds I32) I32
+    :foreign_name sleep
+
+  :ffi _windows_sleep_milliseconds(milliseconds U32) None
+    :foreign_name Sleep

--- a/src/Time.Measure.savi
+++ b/src/Time.Measure.savi
@@ -42,7 +42,8 @@
   :fun current_nanoseconds U64
     case (
     | Platform.is_windows |
-      0 // TODO: Windows support
+      // Windows gives us a "performance counter" and also us the time unit.
+      _FFI.windows_perf_counter * 1000000000 / _FFI.windows_perf_freq
     | Platform.is_macos |
       // MacOS gives us a count of total uptime "ticks" since the OS booted.
       // We don't know how long a "tick" is without asking the operating system,
@@ -84,7 +85,8 @@
   :fun current_microseconds U64
     case (
     | Platform.is_windows |
-      0 // TODO: Windows support
+      // Windows gives us a "performance counter" and also us the time unit.
+      _FFI.windows_perf_counter * 1000000 / _FFI.windows_perf_freq
     | Platform.is_macos |
       // MacOS gives us a count of total uptime "ticks" since the OS booted.
       // We don't know how long a "tick" is without asking the operating system,
@@ -126,7 +128,8 @@
   :fun current_milliseconds U64
     case (
     | Platform.is_windows |
-      0 // TODO: Windows support
+      // Windows gives us a "performance counter" and also us the time unit.
+      _FFI.windows_perf_counter * 1000 / _FFI.windows_perf_freq
     | Platform.is_macos |
       // MacOS gives us a count of total uptime "ticks" since the OS booted.
       // We don't know how long a "tick" is without asking the operating system,

--- a/src/Time.savi
+++ b/src/Time.savi
@@ -38,9 +38,13 @@
   :const _days_per_100_years U64: 36524
   :const _days_per_4_years U64: 1461
 
-  :const _unix_epoch U64: 62135596800
+  :const _unix_epoch U64: 62135596800 // January 1, 1970 (midnight)
   :fun non unix_epoch
     @seconds(@_unix_epoch)
+
+  :const _windows_epoch U64: 50491123200 // January 1, 1601 (midnight)
+  :fun non windows_epoch
+    @seconds(@_windows_epoch)
 
   :: The total number of seconds since `0001-01-01 00:00:00.0` UTC
   :let total_seconds U64
@@ -388,9 +392,15 @@
   :new now
     case (
     | Platform.is_windows |
-      // TODO: Windows support
-      @total_seconds = 0
-      @nanosecond = 0
+      // Windows gives us two U32s to be treated as a U64, indicating the
+      // number of 100ns since the Windows epoch (January 1, 1601).
+      windows_pair = Pair(U32, U32).new(0, 0)
+      _FFI.windows_system_time(stack_address_of_variable windows_pair)
+      raw = windows_pair.first.u64.bit_or(windows_pair.last.u64.bit_shl(32))
+      unit = (@_nanoseconds_per_second / 100).u64
+      absolute = raw + @_windows_epoch * unit
+      @total_seconds = total_seconds = absolute / unit
+      @nanosecond = (absolute - (@total_seconds * unit)).u32 * 100
     | Platform.is_macos |
       // MacOS gives us the seconds since unix epoch and microseconds as a pair.
       // We could also get the time zone here, but we don't; we pass null there.

--- a/src/_FFI.savi
+++ b/src/_FFI.savi
@@ -15,7 +15,29 @@
   :ffi mach_absolute_time U64
 
   :: C function used to get the numerator and denominator for ticks on MacOS.
-  :ffi mach_timebase_info(info CPointer(Pair(U32, U32))) I32
+  :ffi mach_timebase_info(out CPointer(Pair(U32, U32))) I32
+
+  :: C function used to get the performance counter value on Windows.
+  :ffi _windows_query_perf_counter(out CPointer(Pair(U32, U32))) Bool
+    :foreign_name QueryPerformanceCounter
+  :fun windows_perf_counter U64
+    :inline always
+    pair = Pair(U32, U32).new(0, 0)
+    @_windows_query_perf_counter(stack_address_of_variable pair)
+    pair.first.u64.bit_or(pair.last.u64.bit_shl(32))
+
+  :: C function used to get the performance counter frequency on Windows.
+  :ffi _windows_query_perf_freq(out CPointer(Pair(U32, U32))) Bool
+    :foreign_name QueryPerformanceFrequency
+  :fun windows_perf_freq U64
+    :inline always
+    pair = Pair(U32, U32).new(0, 0)
+    @_windows_query_perf_freq(stack_address_of_variable pair)
+    pair.first.u64.bit_or(pair.last.u64.bit_shl(32))
+
+  :: C function used to get the current system wall clock time on Windows.
+  :ffi windows_system_time(out CPointer(Pair(U32, U32))) None
+    :foreign_name GetSystemTimeAsFileTime
 
 :: Clock IDs to use when calling `_FFI.clock_gettime`.
 :module _FFI.ClockType


### PR DESCRIPTION
The `Time` library now builds and passes tests on Windows.